### PR TITLE
Ability to change the coverage-id

### DIFF
--- a/src/LiveCodeCoverage/LiveCodeCoverage.php
+++ b/src/LiveCodeCoverage/LiveCodeCoverage.php
@@ -24,6 +24,7 @@ final class LiveCodeCoverage
 
     private function __construct(CodeCoverage $codeCoverage, $storageDirectory, $coverage_id)
     {
+        Assert::regex($coverage_id, '/^[\w\-]+$/');
         $this->codeCoverage = $codeCoverage;
         $this->coverage_id = $coverage_id;
         Assert::directory($storageDirectory);
@@ -40,7 +41,6 @@ final class LiveCodeCoverage
             $codeCoverage = CodeCoverageFactory::createDefault();
         }
 
-        Assert::regex($coverage_id, '/^[\w\-]+$/');
         $liveCodeCoverage = new self($codeCoverage, $storageDirectory, $coverage_id);
 
         $liveCodeCoverage->start();

--- a/src/LiveCodeCoverage/LiveCodeCoverage.php
+++ b/src/LiveCodeCoverage/LiveCodeCoverage.php
@@ -40,6 +40,7 @@ final class LiveCodeCoverage
             $codeCoverage = CodeCoverageFactory::createDefault();
         }
 
+        Assert::regex($coverage_id, '/^[\w\-]+$/');
         $liveCodeCoverage = new self($codeCoverage, $storageDirectory, $coverage_id);
 
         $liveCodeCoverage->start();

--- a/src/LiveCodeCoverage/LiveCodeCoverage.php
+++ b/src/LiveCodeCoverage/LiveCodeCoverage.php
@@ -10,7 +10,7 @@ final class LiveCodeCoverage
     /**
      * @private
      */
-    const COVERAGE_ID = 'live-coverage';
+    private $coverage_id = 'live-coverage';
 
     /**
      * @var CodeCoverage
@@ -22,16 +22,16 @@ final class LiveCodeCoverage
      */
     private $storageDirectory;
 
-    private function __construct(CodeCoverage $codeCoverage, $storageDirectory)
+    private function __construct(CodeCoverage $codeCoverage, $storageDirectory, $coverage_id)
     {
         $this->codeCoverage = $codeCoverage;
-
+        $this->coverage_id = $coverage_id;
         Assert::directory($storageDirectory);
         Assert::writable($storageDirectory);
         $this->storageDirectory = $storageDirectory;
     }
 
-    public static function bootstrap($storageDirectory, $phpunitConfigFilePath = null)
+    public static function bootstrap($storageDirectory, $phpunitConfigFilePath = null, $coverage_id = 'live-coverage')
     {
         if ($phpunitConfigFilePath !== null) {
             Assert::file($phpunitConfigFilePath);
@@ -40,7 +40,7 @@ final class LiveCodeCoverage
             $codeCoverage = CodeCoverageFactory::createDefault();
         }
 
-        $liveCodeCoverage = new self($codeCoverage, $storageDirectory);
+        $liveCodeCoverage = new self($codeCoverage, $storageDirectory, $coverage_id);
 
         $liveCodeCoverage->start();
         register_shutdown_function([$liveCodeCoverage, 'stopAndSave']);
@@ -48,7 +48,7 @@ final class LiveCodeCoverage
 
     private function start()
     {
-        $this->codeCoverage->start(self::COVERAGE_ID);
+        $this->codeCoverage->start($this->coverage_id);
     }
 
     public function stopAndSave()
@@ -62,7 +62,7 @@ final class LiveCodeCoverage
     private function generateCovFileName()
     {
         $fileNameParts = [
-            self::COVERAGE_ID,
+            $this->coverage_id,
             date('YmdHis'),
             uniqid('', true)
         ];


### PR DESCRIPTION
Hi!

First of all, I really LOVE this package! It gave me the ability to create coverage-files for laravel-tests with Laravel Dusk. As it is a separate process, I was unable to create coverage for those tests. With this package, I can!

However, I still wanted to see which test ran on which line. So, I created these additions so I can bootstrap the package with a pre-set configuration. 

For implementation in Dusk I am setting a cookie pre-dusk and retrieve the cookie in the public/index.php file.

