### PR TITLE
Add support PHPUnit 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: false
 language: php
 
 php:
-  - 5.6
-  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 
 before_install:
   - composer selfupdate

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
   "name": "matthiasnoback/live-code-coverage",
   "require": {
-    "php": "^5.6 || ^7.0",
+    "php": "^7.1",
     "webmozart/assert": "^1.2",
-    "phpunit/php-code-coverage": "^4.0 || ^5.2 || ^6.0",
-    "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0"
+    "phpunit/php-code-coverage": "^4.0 || ^5.2 || ^6.0 || ^7.0",
+    "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0 || ^8.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.0/phpunit.xsd"
     bootstrap="vendor/autoload.php"
     colors="true"
 >
     <testsuites>
-        <testsuite>
+        <testsuite name="default">
             <directory>test</directory>
         </testsuite>
     </testsuites>

--- a/test/functional/LiveCodeCoverageTest.php
+++ b/test/functional/LiveCodeCoverageTest.php
@@ -10,7 +10,7 @@ final class LiveCodeCoverageTest extends TestCase
 {
     private $coverageDirectory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->coverageDirectory = __DIR__ . '/coverage';
 


### PR DESCRIPTION
Dropped support for PHP 5.6 and 7.1 since PHPUnit 8 requires `void` return typehint for `setUp` method. These PHP versions aren't supported by PHP itself and a minor release can be published without it being a BC break.