### PR TITLE
PHPUnit 9 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /composer.lock
 coverage
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 language: php
 
 php:
-  - 7.1
-  - 7.2
   - 7.3
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
   "description": "Generate code coverage reports on a live server",
   "license": "MIT",
   "require": {
-    "php": "^7.1",
+    "php": "^7.3",
     "webmozart/assert": "^1.2",
-    "phpunit/php-code-coverage": "^4.0 || ^5.2 || ^6.0 || ^7.0 || ^8.0",
-    "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+    "phpunit/php-code-coverage": "^8.0",
+    "phpunit/phpunit": "^9.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
- Refactored to support PHP Unit 9
- Tested
- Older PHPUnit support dropped
- Minimum Requirement is PHP 7.3 (as it's required with PHPUnit 9)