### PR TITLE
Fix .cov file format

### DIFF
--- a/src/LiveCodeCoverage/Storage.php
+++ b/src/LiveCodeCoverage/Storage.php
@@ -4,6 +4,7 @@ namespace LiveCodeCoverage;
 
 use DirectoryIterator;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Report\PHP;
 use Webmozart\Assert\Assert;
 
 final class Storage
@@ -25,9 +26,10 @@ final class Storage
             }
         }
 
-        $cov = '<?php return unserialize(' . var_export(serialize($coverage), true) . ');';
         $filePath = $storageDirectory . '/' . $name . '.cov';
-        file_put_contents($filePath, $cov);
+
+        $php = new PHP();
+        $php->process($coverage, $filePath);
     }
 
     /**


### PR DESCRIPTION
I was trying to `phpcov merge` 2 ~10MB `.cov` files generated by this package, and noticed it was suspiciously slow: ~3mn.

Now that the `.cov` files are generated using `SebastianBergmann\CodeCoverage\Report\PHP`, `phpcov merge` takes ~4s.